### PR TITLE
Fix: reduce workflow dependencies

### DIFF
--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -22,6 +22,7 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
+        pwd
         [ -d venv ] || python3 -m venv venv
         source venv/bin/activate
         python -m pip install --upgrade pip
@@ -30,12 +31,14 @@ jobs:
         pwd
     - name: Clean up previous
       run: |
+        pwd
         cd blint-db
         pwd
         rm -f info.log
         rm -f blint.db
     - name: Build and upload db
       run: |
+        pwd
         mkdir -p temp
         source venv/bin/activate
         cd blint-db/

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -21,9 +21,11 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        [ -d venv ] || python3 -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python3 -m pip install .
+        cd blint-db && python -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db
@@ -33,8 +35,8 @@ jobs:
       run: |
         mkdir -p temp
         cd blint-db/
-        python3 blint_db/cli.py -f -Z1
-        python3 ./.oras/orasclient.py
+        python blint_db/cli.py -f -Z1
+        python ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -10,8 +10,7 @@ env:
 
 jobs:
   builder-meson-tst:
-    # runs-on: ['self-hosted', 'ubuntu', 'arm64']
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', 'ubuntu', 'arm64']
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -42,7 +42,7 @@ jobs:
         source venv/bin/activate
         cd blint-db/
         pwd
-        python blint_db/cli.py -f -Z1
+        python blint_db/cli.py --clean-start -f -Z1
         python ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -10,7 +10,8 @@ env:
 
 jobs:
   builder-meson-tst:
-    runs-on: ['self-hosted', 'ubuntu', 'arm64']
+    # runs-on: ['self-hosted', 'ubuntu', 'arm64']
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
@@ -29,6 +30,7 @@ jobs:
     - name: Clean up previous
       run: |
         cd blint-db
+        pwd
         rm -f info.log
         rm -f blint.db
     - name: Build and upload db
@@ -36,6 +38,7 @@ jobs:
         mkdir -p temp
         source venv/bin/activate
         cd blint-db/
+        pwd
         python blint_db/cli.py -f -Z1
         python ./.oras/orasclient.py
       env:

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -21,9 +21,9 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python -m pip install .
+        cd blint-db && python3 -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db
@@ -33,8 +33,8 @@ jobs:
       run: |
         mkdir -p temp
         cd blint-db/
-        python blint_db/cli.py -f -Z1
-        python ./.oras/orasclient.py
+        python3 blint_db/cli.py -f -Z1
+        python3 ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -27,6 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine build
         cd blint-db && python -m pip install .
+        pwd
     - name: Clean up previous
       run: |
         cd blint-db

--- a/.github/workflows/build-meson-tst.yml
+++ b/.github/workflows/build-meson-tst.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build and upload db
       run: |
         mkdir -p temp
+        source venv/bin/activate
         cd blint-db/
         python blint_db/cli.py -f -Z1
         python ./.oras/orasclient.py

--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -21,9 +21,11 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        [ -d venv ] || python3 -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python3 -m pip install .
+        cd blint-db && python -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db
@@ -33,8 +35,8 @@ jobs:
       run: |
         mkdir -p temp
         cd blint-db/
-        python3 blint_db/cli.py -Z1
-        python3 ./.oras/orasclient.py
+        python blint_db/cli.py -Z1
+        python ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build and upload db
       run: |
         mkdir -p temp
+        source venv/bin/activate
         cd blint-db/
         python blint_db/cli.py -Z1
         python ./.oras/orasclient.py

--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -36,7 +36,7 @@ jobs:
         mkdir -p temp
         source venv/bin/activate
         cd blint-db/
-        python blint_db/cli.py -Z1
+        python blint_db/cli.py --clean-start -Z1
         python ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -21,9 +21,9 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python -m pip install .
+        cd blint-db && python3 -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db
@@ -33,8 +33,8 @@ jobs:
       run: |
         mkdir -p temp
         cd blint-db/
-        python blint_db/cli.py -Z1
-        python ./.oras/orasclient.py
+        python3 blint_db/cli.py -Z1
+        python3 ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-vcpkg-tst.yml
+++ b/.github/workflows/build-vcpkg-tst.yml
@@ -1,4 +1,4 @@
-name: Build and Upload meson blint-db 0.1.0
+name: Build and Upload vcpkg blint-db 0.1.0
 
 on:
   schedule:
@@ -9,7 +9,7 @@ env:
   IMAGE_NAME: appthreat/blintdb
 
 jobs:
-  builder-meson-tst:
+  builder-vcpkg-tst:
     runs-on: ['self-hosted', 'ubuntu', 'arm64']
     permissions:
       contents: write
@@ -36,8 +36,8 @@ jobs:
         mkdir -p temp
         source venv/bin/activate
         cd blint-db/
-        python blint_db/cli.py --clean-start -f -Z1
-        python ./.oras/orasclient.py
+        python3 blint-db/blint_db/cli.py --clean-start -f -Z2
+        python3 ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -21,9 +21,9 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python -m pip install .
+        cd blint-db && python3 -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db
@@ -33,8 +33,8 @@ jobs:
       run: |
         mkdir -p temp
         cd blint-db/
-        python blint-db/blint_db/cli.py -Z2
-        python ./.oras/orasclient.py
+        python3 blint-db/blint_db/cli.py -Z2
+        python3 ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_USERNAME: ${{ github.actor }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -36,7 +36,7 @@ jobs:
         mkdir -p temp
         source venv/bin/activate
         cd blint-db/
-        python3 blint-db/blint_db/cli.py -Z2
+        python3 blint-db/blint_db/cli.py --clean-start -Z2
         python3 ./.oras/orasclient.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -21,9 +21,11 @@ jobs:
         path: blint-db
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        [ -d venv ] || python3 -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip
         pip install setuptools wheel twine build
-        cd blint-db && python3 -m pip install .
+        cd blint-db && python -m pip install .
     - name: Clean up previous
       run: |
         cd blint-db

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build and upload db
       run: |
         mkdir -p temp
+        source venv/bin/activate
         cd blint-db/
         python3 blint-db/blint_db/cli.py -Z2
         python3 ./.oras/orasclient.py

--- a/.oras/orasclient.py
+++ b/.oras/orasclient.py
@@ -3,7 +3,7 @@ import os
 
 client = oras.client.OrasClient()
 
-token = os.getenv("GITHUB_USERNAME", "")
+token = os.getenv("GITHUB_TOKEN", "")
 username = os.getenv("GITHUB_USERNAME", "")
 
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,8 @@
             "request": "launch",
             "program": "${workspaceFolder}/blint_db/cli.py",
             "console": "integratedTerminal",
-            "args": "-Z1"
+            // "preLaunchTask": "Run Cleanup Script",
+            "args": ["-f", "-Z1"]
         },
         {
             "name": "test nodejs sbom deep",
@@ -38,7 +39,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/blint_db/cli.py",
             "console": "integratedTerminal",
-            "preLaunchTask": "Run Cleanup Script",
+            // "preLaunchTask": "Run Cleanup Script",
             "args": "-Z2"
         }
     ]

--- a/blint_db/cli.py
+++ b/blint_db/cli.py
@@ -131,6 +131,7 @@ def main():
 
     if COMMON_CONNECTION:
         reset_and_backup()
+        print("Build Completed Saved Database")
 
 
 if __name__ == "__main__":

--- a/blint_db/cli.py
+++ b/blint_db/cli.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import sqlite3
 from concurrent import futures
 
 from blint_db import BLINTDB_LOCATION, COMMON_CONNECTION
@@ -72,13 +73,13 @@ def arguments_parser():
         help="Set pkg managers to build fewer projects, helpful for debugging",
     )
 
-    parser.add_argument(
-        "-R",
-        "--reuse-old-db",
-        dest="reuse",
-        action="store_true",
-        help="when set does not create a new database"
-    )
+    # parser.add_argument(
+    #     "-R",
+    #     "--reuse-old-db",
+    #     dest="reuse",
+    #     action="store_true",
+    #     help="when set does not create a new database"
+    # )
 
     return parser.parse_args()
 
@@ -118,19 +119,10 @@ def vcpkg_add_blint_bom_process(test_mode=False):
             reset_and_backup()
             count = 0
 
-    # with futures.ProcessPoolExecutor(max_workers=1) as executor:
-    #     for project_name, executables in zip(
-    #         projects_list, executor.map(mt_vcpkg_blint_db_build, projects_list)
-    #     ):
-    #         print(f"Ran complete for {project_name} and we found {len(executables)}")
-
 
 def main():
 
     args = vars(arguments_parser())
-
-    if not args["reuse"]:
-        create_database()
 
     if args["clean"]:
         clear_sqlite_database()

--- a/blint_db/cli.py
+++ b/blint_db/cli.py
@@ -61,7 +61,6 @@ def arguments_parser():
     parser.add_argument(
         "--clean-start",
         dest="clean",
-        default=False,
         action="store_true",
         help="Resets the database before starting a new build",
     )

--- a/blint_db/cli.py
+++ b/blint_db/cli.py
@@ -69,7 +69,15 @@ def arguments_parser():
         "--few-packages",
         dest="test_mode",
         action="store_true",
-        help="Set meson to build fewer projects, helpful for debugging",
+        help="Set pkg managers to build fewer projects, helpful for debugging",
+    )
+
+    parser.add_argument(
+        "-R",
+        "--reuse-old-db",
+        dest="reuse",
+        action="store_true",
+        help="when set does not create a new database"
     )
 
     return parser.parse_args()
@@ -96,8 +104,10 @@ def meson_add_blint_bom_process(test_mode=False):
             print(f"Ran complete for {project_name} and we found {len(executables)}")
 
 
-def vcpkg_add_blint_bom_process():
+def vcpkg_add_blint_bom_process(test_mode=False):
     projects_list = get_vcpkg_projects()
+    if test_mode:
+        projects_list = projects_list[:10]
     count = 0
     for project_name in projects_list:
         executables = mt_vcpkg_blint_db_build(project_name)
@@ -119,6 +129,9 @@ def main():
 
     args = vars(arguments_parser())
 
+    if not args["reuse"]:
+        create_database()
+
     if args["clean"]:
         clear_sqlite_database()
         create_database()
@@ -127,7 +140,7 @@ def main():
         meson_add_blint_bom_process(args["test_mode"])
 
     if args["vcpkg"]:
-        vcpkg_add_blint_bom_process()
+        vcpkg_add_blint_bom_process(args["test_mode"])
 
     if COMMON_CONNECTION:
         reset_and_backup()

--- a/blint_db/config.py
+++ b/blint_db/config.py
@@ -28,5 +28,5 @@ CWD = Path(os.getcwd())
 
 SQLITE_TIMEOUT = 20.0
 
-# COMMON_CONNECTION = None
-COMMON_CONNECTION = sqlite3.connect(":memory:")
+COMMON_CONNECTION = None
+# COMMON_CONNECTION = sqlite3.connect(":memory:")

--- a/blint_db/config.py
+++ b/blint_db/config.py
@@ -10,7 +10,7 @@ logging.basicConfig(
 
 DELIMETER_BOM = "~~"
 # variables
-DEBUG_MODE = True
+DEBUG_MODE = False
 # constants
 TEMP_PATH = Path.cwd() / "temp"
 WRAPDB_LOCATION = TEMP_PATH / "wrapdb"

--- a/blint_db/handlers/sqlite_handler.py
+++ b/blint_db/handlers/sqlite_handler.py
@@ -8,6 +8,7 @@ from blint_db import (BLINTDB_LOCATION, COMMON_CONNECTION, DEBUG_MODE,
                       SQLITE_TIMEOUT)
 
 
+
 def use_existing_connection(connection=None):  # Decorator now accepts connection
     """
     Decorator to use an existing connection when BLINTDB_LOCATION is ':memory:'.
@@ -18,7 +19,7 @@ def use_existing_connection(connection=None):  # Decorator now accepts connectio
         def wrapper(*args, **kwargs):
             if connection:
                 with closing(connection.cursor()) as c:
-                    if len(args) > 1:  # Statement and arguments provided
+                    if len(args) > 1:
                         c.execute(args[0], args[1])
                     else:
                         c.execute(args[0])
@@ -196,7 +197,3 @@ def add_binary_export(infunc, bid):
     execute_statement(
         "INSERT INTO BinariesExports (bid, eid) VALUES (?, ?)", (bid, eid)
     )
-
-
-if not os.path.exists(BLINTDB_LOCATION):
-    create_database()

--- a/blint_db/handlers/sqlite_handler.py
+++ b/blint_db/handlers/sqlite_handler.py
@@ -118,7 +118,9 @@ def create_database():
 
 
 def clear_sqlite_database():
-    os.remove(BLINTDB_LOCATION)
+    if os.path.exists(BLINTDB_LOCATION):
+        if os.path.isfile(BLINTDB_LOCATION):
+            os.remove(BLINTDB_LOCATION)
 
 
 def store_sbom_in_sqlite(purl, sbom):


### PR DESCRIPTION
This PR improve the stability of workflows by disabling the temporary in-memory sqlite3 database.
Changes DEBUG_MODE of the repo to `false`.
Introduces `tst` workflows for both vcpkg and meson, which run only on 10 projects each to get a faster test debug cycle