### PR TITLE
Add SQLite compaction, performance tuning, and provenance stats

### DIFF
--- a/.oras/orasclient.py
+++ b/.oras/orasclient.py
@@ -15,7 +15,9 @@ username = os.getenv("GITHUB_USERNAME", "")
 db_version = os.getenv("BLINT_DB_VERSION", "v2")
 db_file = os.getenv("BLINT_DB_FILE", "./blint.db")
 metadata_file = os.getenv("BLINT_DB_METADATA_FILE")
-client.login(password=token, username=username)
+registry = os.getenv("REGISTRY", "ghcr.io")
+image_name = os.getenv("IMAGE_NAME", "appthreat/blintdb")
+client.login(server=registry, password=token, username=username)
 
 
 def default_metadata_path(db_path: str) -> str:
@@ -46,7 +48,7 @@ if pkg := args.get("pkg", None):
             f"{resolved_metadata_file}:application/vnd.appthreat.blintdb.metadata.v1+json"
         )
     client.push(
-        target=f"ghcr.io/appthreat/blintdb-{pkg}:{db_version}",
+        target=f"{registry}/{image_name}-{pkg}:{db_version}",
         config_path="./.oras/config.json",
         annotation_file="./.oras/annotations.json",
         files=files,

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ export BLINT_DB_MESON_STRIP=0
 python -m blint_db.cli --clean-start --db-file ./temp/meson-small.db --disassemble build-meson -s zlib bzip2
 ```
 
-Build artifacts are removed by the CLI after ingestion, so rebuild the selected projects in-place when you want binaries for analyst-side validation:
+Build artifacts are removed by the CLI after ingestion by default. If you want to keep the Meson/vcpkg build outputs for analyst-side validation or debugging, pass `--retain-build-artifacts`; otherwise, rebuild the selected projects in-place when you want binaries for analyst-side validation:
 
 ```bash
 cd /path/to/blint-db

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The goal is to make `blint-db` a stronger package-identification corpus for `bli
 
 `blint-db` is published via GitHub Packages and Hugging Face datasets.
 
+Each generated database is compacted before the run completes. The build pipeline checkpoints and truncates WAL state, runs `VACUUM`, and records SQLite page and freelist statistics in the provenance sidecar.
+
 ## Why v2
 
 `blint` 3 exposes much richer metadata than the old deep SBOM properties used by the original `blint-db` pipeline. v2 therefore ingests the primary metadata contract directly instead of flattening everything through CycloneDX properties.
@@ -142,6 +144,28 @@ Key fields:
 - `instruction_metrics_json`
 - register and call-target summaries
 
+## Storage and compaction policy
+
+`blint-db` keeps write-time performance reasonable while still producing compact final artifacts.
+
+Current SQLite tuning includes:
+
+- `page_size=4096`
+- `auto_vacuum=INCREMENTAL`
+- `journal_mode=WAL`
+- `journal_size_limit=1048576`
+- `temp_store=MEMORY`
+- `secure_delete=OFF`
+
+At the end of each ingest or ecosystem build command, `blint-db` performs:
+
+- `PRAGMA wal_checkpoint(TRUNCATE)`
+- `PRAGMA optimize`
+- `VACUUM`
+- `PRAGMA incremental_vacuum`
+
+This keeps the shipped database file small without forcing slow full compaction after every individual binary insert.
+
 ## CLI overview
 
 The CLI has two primary modes:
@@ -179,6 +203,13 @@ Meson / wrapdb:
 
 ```bash
 blint-db --db-file blint-v2.db --clean-start --disassemble build-meson
+```
+
+For a smaller real corpus that is useful for local SBOM end-to-end checks:
+
+```bash
+export BLINT_DB_MESON_STRIP=0
+blint-db --db-file ./temp/meson-small.db --clean-start --disassemble build-meson -s zlib bzip2
 ```
 
 vcpkg:
@@ -240,6 +271,8 @@ blint-db --db-file blint-v2.db --clean-start -f build-conan
 ```
 
 Each ecosystem build also emits a provenance sidecar JSON next to the database by default (for example `blint.metadata.json` when the database is `blint.db`).
+That sidecar includes final table counts and SQLite size statistics after compaction.
+Its `projects` block also records `selected_count`, `attempted_count`, `success_count`, `failure_count`, `status_counts`, and `build_failures`. Each `projects.build_failures[]` entry is a flattened per-project failure record derived from `projects.outcomes[].failure`, with stable keys such as `selector`, `project_name`, `ecosystem`, `build_system`, `status`, `stage`, and `message`, plus optional fields like `returncode` and `exception_type` when available.
 
 Legacy aliases are still accepted for workflow continuity:
 
@@ -453,6 +486,56 @@ cd /path/to/blint-db
 uv sync --all-extras --dev
 uv pip install --python .venv/bin/python --editable /path/to/blint
 ```
+
+### Real end-to-end validation with `blint`
+
+A reproducible local check is available directly in the `blint` repo:
+
+```bash
+cd /path/to/blint
+python tests/scripts/validate_blintdb_small_corpus.py --ecosystems meson
+python tests/scripts/validate_blintdb_small_corpus.py --ecosystems vcpkg
+python tests/scripts/validate_blintdb_small_corpus.py --ecosystems homebrew
+```
+
+The script reads `tests/data/blintdb-small-corpus.json`, builds the requested databases, retains the relevant artifacts, runs `blint sbom` in normal and deep modes, and writes a JSON summary under `.tmp-blintdb-small-corpus/`.
+
+If you want to run the Meson flow manually, the equivalent steps are:
+
+```bash
+cd /path/to/blint-db
+export BLINT_DB_MESON_STRIP=0
+python -m blint_db.cli --clean-start --db-file ./temp/meson-small.db --disassemble build-meson -s zlib bzip2
+```
+
+Build artifacts are removed by the CLI after ingestion, so rebuild the selected projects in-place when you want binaries for analyst-side validation:
+
+```bash
+cd /path/to/blint-db
+python - <<'PY'
+from blint_db.handlers.language_handlers.meson_handler import find_meson_executables, meson_build
+
+for project_name in ("zlib", "bzip2"):
+    meson_build(project_name)
+    for binary in find_meson_executables(project_name):
+        print(binary)
+PY
+```
+
+Then point `blint` at the generated database:
+
+```bash
+cd /path/to/blint
+mkdir -p ./.tmp-meson-db
+cp /path/to/blint-db/temp/meson-small.db ./.tmp-meson-db/blint.db
+export BLINTDB_HOME=$PWD/.tmp-meson-db
+export USE_BLINTDB=true
+
+poetry run blint sbom -i /path/to/libz.1.dylib --use-blintdb --stdout
+poetry run blint sbom -i /path/to/libz.1.dylib --use-blintdb --deep --stdout
+```
+
+For binaries that were built into the corpus itself, expect near-exact package identification in both modes. In deep mode, the matched component should also carry non-zero `internal:blintdb_matched_instruction_hash_count` or `internal:blintdb_matched_assembly_hash_count` evidence.
 
 ## Workflow notes
 

--- a/blint_db/cli.py
+++ b/blint_db/cli.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import Any, List
 
 from blint_db import (
     BLINT_DB_FILE,
@@ -42,7 +42,11 @@ from blint_db.handlers.language_handlers.wrapdb_handler import (
     get_wrapdb_projects,
     remove_wrapdb_project,
 )
-from blint_db.handlers.sqlite_handler import clear_sqlite_database, create_database
+from blint_db.handlers.sqlite_handler import (
+    clear_sqlite_database,
+    compact_database,
+    create_database,
+)
 from blint_db.ingest import infer_project_name, ingest_binary_file, ingest_metadata_file
 from blint_db.projects_compiler.cargo import mt_cargo_blint_db_build
 from blint_db.projects_compiler.conan import mt_conan_blint_db_build
@@ -61,7 +65,7 @@ def build_parser():
         "--db-file",
         dest="db_file",
         default=BLINT_DB_FILE,
-        help="SQLite database file to create or update. Defaults to blint.db.",
+        help=f"SQLite database file to create or update. Defaults to {BLINT_DB_FILE}.",
     )
     parser.add_argument(
         "--run-metadata-file",
@@ -190,9 +194,9 @@ def build_parser():
     )
     _add_build_selection_arguments(build_meson_parser)
     build_meson_parser.add_argument(
-        "--remove-after-build",
+        "--retain-build-artifacts",
         dest="remove_after_build",
-        action="store_true",
+        action="store_false",
         default=True,
         help=argparse.SUPPRESS,
     )
@@ -203,9 +207,9 @@ def build_parser():
     )
     _add_build_selection_arguments(build_vcpkg_parser)
     build_vcpkg_parser.add_argument(
-        "--remove-after-build",
+        "--retain-build-artifacts",
         dest="remove_after_build",
-        action="store_true",
+        action="store_false",
         default=True,
         help=argparse.SUPPRESS,
     )
@@ -369,7 +373,9 @@ def meson_add_blint_bom_process(
     disassemble: bool = False,
     test_mode: bool = False,
     sel_project: List | None = None,
-):
+    remove_after_build: bool = True,
+) -> list[dict[str, Any]]:
+    project_outcomes: list[dict[str, Any]] = []
     projects_list = get_wrapdb_projects()
     projects_list = _resolve_selected_wrapdb_projects(projects_list, sel_project)
     if test_mode:
@@ -379,11 +385,14 @@ def meson_add_blint_bom_process(
             project_name_tuple,
             db_file=db_file,
             disassemble=disassemble,
+            project_outcomes=project_outcomes,
         )
         print(
             f"Build complete for {project_name_tuple[0]}. Got {len(executables)} binaries."
         )
-        remove_wrapdb_project(project_name_tuple[0])
+        if remove_after_build:
+            remove_wrapdb_project(project_name_tuple[0])
+    return project_outcomes
 
 
 def remove_temp_ar():
@@ -407,7 +416,9 @@ def vcpkg_add_blint_bom_process(
     disassemble: bool = False,
     test_mode: bool = False,
     sel_project: List | None = None,
-):
+    remove_after_build: bool = True,
+) -> list[dict[str, Any]]:
+    project_outcomes: list[dict[str, Any]] = []
     projects_list = get_vcpkg_projects()
     projects_list = _resolve_selected_vcpkg_projects(projects_list, sel_project)
     if test_mode:
@@ -421,13 +432,16 @@ def vcpkg_add_blint_bom_process(
             vcpkg_json,
             db_file=db_file,
             disassemble=disassemble,
+            project_outcomes=project_outcomes,
         )
         print(f"Build complete for {project_name}. Got {len(executables)} binaries.")
-        remove_vcpkg_project(project_name)
+        if remove_after_build:
+            remove_vcpkg_project(project_name)
         count += 1
-        if count == 10:
+        if remove_after_build and count == 10:
             remove_temp_ar()
             count = 0
+    return project_outcomes
 
 
 def homebrew_add_blint_bom_process(
@@ -436,7 +450,8 @@ def homebrew_add_blint_bom_process(
     disassemble: bool = False,
     test_mode: bool = False,
     sel_project: List | None = None,
-):
+) -> list[dict[str, Any]]:
+    project_outcomes: list[dict[str, Any]] = []
     projects_list = (
         load_curated_homebrew_projects() if test_mode else get_homebrew_projects()
     )
@@ -452,8 +467,10 @@ def homebrew_add_blint_bom_process(
             formula_name,
             db_file=db_file,
             disassemble=disassemble,
+            project_outcomes=project_outcomes,
         )
         print(f"Build complete for {formula_name}. Got {len(executables)} binaries.")
+    return project_outcomes
 
 
 def cargo_add_blint_bom_process(
@@ -462,7 +479,8 @@ def cargo_add_blint_bom_process(
     disassemble: bool = False,
     test_mode: bool = False,
     sel_project: List | None = None,
-):
+) -> list[dict[str, Any]]:
+    project_outcomes: list[dict[str, Any]] = []
     projects_list = (
         get_cargo_projects() if not test_mode else load_curated_cargo_projects()
     )
@@ -480,10 +498,12 @@ def cargo_add_blint_bom_process(
             project_spec,
             db_file=db_file,
             disassemble=disassemble,
+            project_outcomes=project_outcomes,
         )
         print(
             f"Build complete for {project_spec.selector}. Got {len(executables)} binaries."
         )
+    return project_outcomes
 
 
 def conan_add_blint_bom_process(
@@ -492,7 +512,8 @@ def conan_add_blint_bom_process(
     disassemble: bool = False,
     test_mode: bool = False,
     sel_project: List | None = None,
-):
+) -> list[dict[str, Any]]:
+    project_outcomes: list[dict[str, Any]] = []
     projects_list = _require_curated_projects(
         load_curated_conan_projects(),
         ecosystem="Conan",
@@ -506,10 +527,12 @@ def conan_add_blint_bom_process(
             project_spec,
             db_file=db_file,
             disassemble=disassemble,
+            project_outcomes=project_outcomes,
         )
         print(
             f"Build complete for {project_spec.selector}. Got {len(executables)} binaries."
         )
+    return project_outcomes
 
 
 def _run_ingest(args):
@@ -567,6 +590,19 @@ def _run_ingest(args):
     )
 
 
+def _compact_and_report(db_file: str):
+    stats = compact_database(db_file)
+    before = stats["before"]
+    after = stats["after"]
+    print(
+        "Compacted database "
+        f"{db_file}: size {before['size_bytes']} -> {after['size_bytes']} bytes, "
+        f"freelist {before['freelist_count']} -> {after['freelist_count']}, "
+        f"wal {before['wal_size_bytes']} -> {after['wal_size_bytes']} bytes"
+    )
+    return stats
+
+
 def main():
     args = arguments_parser()
     command = _resolve_command(args)
@@ -578,13 +614,16 @@ def main():
     create_database(args.db_file)
     if command == "ingest":
         _run_ingest(args)
+        _compact_and_report(args.db_file)
     elif command == "build-meson":
-        meson_add_blint_bom_process(
+        project_outcomes = meson_add_blint_bom_process(
             db_file=args.db_file,
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             sel_project=args.sel_project,
+            remove_after_build=args.remove_after_build,
         )
+        _compact_and_report(args.db_file)
         metadata_path = write_run_metadata(
             command=command,
             db_file=args.db_file,
@@ -592,15 +631,18 @@ def main():
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             selected_projects=args.sel_project,
+            project_outcomes=project_outcomes,
         )
         print(f"Wrote build metadata to {metadata_path}")
     elif command == "build-vcpkg":
-        vcpkg_add_blint_bom_process(
+        project_outcomes = vcpkg_add_blint_bom_process(
             db_file=args.db_file,
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             sel_project=args.sel_project,
+            remove_after_build=args.remove_after_build,
         )
+        _compact_and_report(args.db_file)
         metadata_path = write_run_metadata(
             command=command,
             db_file=args.db_file,
@@ -608,15 +650,17 @@ def main():
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             selected_projects=args.sel_project,
+            project_outcomes=project_outcomes,
         )
         print(f"Wrote build metadata to {metadata_path}")
     elif command == "build-homebrew":
-        homebrew_add_blint_bom_process(
+        project_outcomes = homebrew_add_blint_bom_process(
             db_file=args.db_file,
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             sel_project=args.sel_project,
         )
+        _compact_and_report(args.db_file)
         metadata_path = write_run_metadata(
             command=command,
             db_file=args.db_file,
@@ -624,15 +668,17 @@ def main():
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             selected_projects=args.sel_project,
+            project_outcomes=project_outcomes,
         )
         print(f"Wrote build metadata to {metadata_path}")
     elif command == "build-cargo":
-        cargo_add_blint_bom_process(
+        project_outcomes = cargo_add_blint_bom_process(
             db_file=args.db_file,
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             sel_project=args.sel_project,
         )
+        _compact_and_report(args.db_file)
         metadata_path = write_run_metadata(
             command=command,
             db_file=args.db_file,
@@ -640,15 +686,17 @@ def main():
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             selected_projects=args.sel_project,
+            project_outcomes=project_outcomes,
         )
         print(f"Wrote build metadata to {metadata_path}")
     elif command == "build-conan":
-        conan_add_blint_bom_process(
+        project_outcomes = conan_add_blint_bom_process(
             db_file=args.db_file,
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             sel_project=args.sel_project,
         )
+        _compact_and_report(args.db_file)
         metadata_path = write_run_metadata(
             command=command,
             db_file=args.db_file,
@@ -656,6 +704,7 @@ def main():
             disassemble=args.disassemble,
             test_mode=args.test_mode,
             selected_projects=args.sel_project,
+            project_outcomes=project_outcomes,
         )
         print(f"Wrote build metadata to {metadata_path}")
 

--- a/blint_db/handlers/sqlite_handler.py
+++ b/blint_db/handlers/sqlite_handler.py
@@ -20,9 +20,13 @@ from blint_db import (
 from blint_db.utils.json import canonical_json_dumps, coerce_json_object
 
 _SCHEMA_SQL = """
+PRAGMA page_size = 4096;
+PRAGMA auto_vacuum = INCREMENTAL;
 PRAGMA journal_mode = WAL;
 PRAGMA synchronous = NORMAL;
 PRAGMA temp_store = MEMORY;
+PRAGMA secure_delete = OFF;
+PRAGMA journal_size_limit = 1048576;
 
 CREATE TABLE IF NOT EXISTS SchemaMeta (
     key TEXT PRIMARY KEY,
@@ -166,10 +170,15 @@ CREATE INDEX IF NOT EXISTS idx_builds_project ON Builds(project_id);
 CREATE INDEX IF NOT EXISTS idx_binaries_build ON Binaries(build_id);
 CREATE INDEX IF NOT EXISTS idx_binaries_sha256 ON Binaries(sha256);
 CREATE INDEX IF NOT EXISTS idx_binaries_language ON Binaries(language);
+CREATE INDEX IF NOT EXISTS idx_binaries_type_target ON Binaries(binary_type, llvm_target_tuple, binary_id);
 CREATE INDEX IF NOT EXISTS idx_symbols_name ON Symbols(name);
 CREATE INDEX IF NOT EXISTS idx_symbols_source ON Symbols(source);
+CREATE INDEX IF NOT EXISTS idx_symbols_lookup ON Symbols(name, source, binary_id);
+CREATE INDEX IF NOT EXISTS idx_symbols_binary_lookup ON Symbols(binary_id, source, name);
 CREATE INDEX IF NOT EXISTS idx_functions_instruction_hash ON FunctionFingerprints(instruction_hash);
 CREATE INDEX IF NOT EXISTS idx_functions_assembly_hash ON FunctionFingerprints(assembly_hash);
+CREATE INDEX IF NOT EXISTS idx_functions_instruction_hash_binary ON FunctionFingerprints(instruction_hash, binary_id);
+CREATE INDEX IF NOT EXISTS idx_functions_assembly_hash_binary ON FunctionFingerprints(assembly_hash, binary_id);
 """
 
 
@@ -207,6 +216,7 @@ def get_connection(db_file: str | None = None):
     connection = sqlite3.connect(database_file, timeout=SQLITE_TIMEOUT)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("PRAGMA temp_store = MEMORY")
     try:
         yield connection
         connection.commit()
@@ -296,6 +306,57 @@ def ensure_database(db_file: str | None = None):
         create_database(database_file)
         return
     _validate_schema_contract(database_file)
+
+
+def collect_database_stats(db_file: str | None = None) -> dict[str, int | str]:
+    database_file = db_file or BLINT_DB_FILE
+    if not os.path.exists(database_file):
+        return {
+            "database_file": str(database_file),
+            "size_bytes": 0,
+            "page_count": 0,
+            "freelist_count": 0,
+            "page_size": 0,
+            "wal_size_bytes": 0,
+            "shm_size_bytes": 0,
+        }
+    with get_connection(database_file) as connection:
+        page_count = int(connection.execute("PRAGMA page_count").fetchone()[0] or 0)
+        freelist_count = int(
+            connection.execute("PRAGMA freelist_count").fetchone()[0] or 0
+        )
+        page_size = int(connection.execute("PRAGMA page_size").fetchone()[0] or 0)
+    wal_path = f"{database_file}-wal"
+    shm_path = f"{database_file}-shm"
+    return {
+        "database_file": str(database_file),
+        "size_bytes": os.path.getsize(database_file),
+        "page_count": page_count,
+        "freelist_count": freelist_count,
+        "page_size": page_size,
+        "wal_size_bytes": os.path.getsize(wal_path) if os.path.exists(wal_path) else 0,
+        "shm_size_bytes": os.path.getsize(shm_path) if os.path.exists(shm_path) else 0,
+    }
+
+
+def compact_database(db_file: str | None = None) -> dict[str, dict[str, int | str]]:
+    """Checkpoint and vacuum the database to reduce final artifact size."""
+    database_file = db_file or BLINT_DB_FILE
+    if not os.path.exists(database_file):
+        return {
+            "before": collect_database_stats(database_file),
+            "after": collect_database_stats(database_file),
+        }
+    before = collect_database_stats(database_file)
+    with get_connection(database_file) as connection:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        connection.execute("PRAGMA optimize")
+        connection.execute("VACUUM")
+        connection.execute("PRAGMA incremental_vacuum")
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        connection.execute("PRAGMA optimize")
+    after = collect_database_stats(database_file)
+    return {"before": before, "after": after}
 
 
 def upsert_project(

--- a/blint_db/projects_compiler/cargo.py
+++ b/blint_db/projects_compiler/cargo.py
@@ -13,6 +13,12 @@ from blint_db.handlers.language_handlers.cargo_handler import (
     build_cargo_project,
 )
 from blint_db.ingest import ingest_binary_file
+from blint_db.utils.provenance import build_failure_record, build_project_outcome
+
+
+def _record_outcome(project_outcomes, **kwargs):
+    if project_outcomes is not None:
+        project_outcomes.append(build_project_outcome(**kwargs))
 
 
 def add_project_cargo_db(
@@ -20,37 +26,31 @@ def add_project_cargo_db(
     db_file: str | None = None,
     disassemble: bool = False,
 ):
-    try:
-        build_result = build_cargo_project(project_spec)
-        for artifact_path in build_result.artifacts:
-            try:
-                ingest_binary_file(
-                    artifact_path,
-                    db_file=db_file,
-                    project_name=project_spec.crate,
-                    project_purl=build_result.project_purl,
-                    ecosystem="cargo",
-                    project_metadata=build_result.project_metadata,
-                    build_system="cargo",
-                    target_os=build_result.target_os,
-                    target_arch=build_result.target_arch,
-                    target_triplet=build_result.target_triplet,
-                    build_mode=build_result.build_mode,
-                    optimization=build_result.optimization,
-                    strip_status=build_result.strip_status,
-                    build_metadata=build_result.build_metadata,
-                    relative_to=build_result.target_dir,
-                    disassemble=disassemble,
-                )
-            except (RuntimeError, FileNotFoundError) as exc:
-                logger.info(f"error encountered with {project_spec.selector}")
-                logger.error(exc)
-                logger.error(traceback.format_exc())
-    except RuntimeError as exc:
-        logger.info(f"error encountered with {project_spec.selector}")
-        logger.error(exc)
-        logger.error(traceback.format_exc())
-        return []
+    build_result = build_cargo_project(project_spec)
+    for artifact_path in build_result.artifacts:
+        try:
+            ingest_binary_file(
+                artifact_path,
+                db_file=db_file,
+                project_name=project_spec.crate,
+                project_purl=build_result.project_purl,
+                ecosystem="cargo",
+                project_metadata=build_result.project_metadata,
+                build_system="cargo",
+                target_os=build_result.target_os,
+                target_arch=build_result.target_arch,
+                target_triplet=build_result.target_triplet,
+                build_mode=build_result.build_mode,
+                optimization=build_result.optimization,
+                strip_status=build_result.strip_status,
+                build_metadata=build_result.build_metadata,
+                relative_to=build_result.target_dir,
+                disassemble=disassemble,
+            )
+        except (RuntimeError, FileNotFoundError) as exc:
+            logger.info(f"error encountered with {project_spec.selector}")
+            logger.error(exc)
+            logger.error(traceback.format_exc())
     return build_result.artifacts
 
 
@@ -58,16 +58,50 @@ def mt_cargo_blint_db_build(
     project_spec: CargoProjectSpec,
     db_file: str | None = None,
     disassemble: bool = False,
+    project_outcomes=None,
 ):
     logger.debug("Running cargo crate %s", project_spec.selector)
     try:
-        return add_project_cargo_db(
+        artifacts = add_project_cargo_db(
             project_spec,
             db_file=db_file,
             disassemble=disassemble,
         )
-    except OperationalError as exc:
+        failure = None
+        status = "success"
+        if not artifacts:
+            status = "no_artifacts"
+            failure = build_failure_record(
+                stage="artifact-discovery",
+                message=f"No cargo artifacts were retained for {project_spec.selector}",
+            )
+        _record_outcome(
+            project_outcomes,
+            selector=project_spec.selector,
+            project_name=project_spec.crate,
+            ecosystem="cargo",
+            build_system="cargo",
+            status=status,
+            artifact_count=len(artifacts),
+            failure=failure,
+        )
+        return artifacts
+    except (OperationalError, RuntimeError) as exc:
         logger.info(f"error encountered with {project_spec.selector}")
         logger.error(exc)
         logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=project_spec.selector,
+            project_name=project_spec.crate,
+            ecosystem="cargo",
+            build_system="cargo",
+            status="build_failed" if isinstance(exc, RuntimeError) else "ingest_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="build" if isinstance(exc, RuntimeError) else "database",
+                message=str(exc),
+                exception=exc,
+            ),
+        )
         return []

--- a/blint_db/projects_compiler/conan.py
+++ b/blint_db/projects_compiler/conan.py
@@ -23,6 +23,12 @@ from blint_db.handlers.language_handlers.conan_handler import (
     parse_conan_reference,
 )
 from blint_db.ingest import ingest_binary_file
+from blint_db.utils.provenance import build_failure_record, build_project_outcome
+
+
+def _record_outcome(project_outcomes, **kwargs):
+    if project_outcomes is not None:
+        project_outcomes.append(build_project_outcome(**kwargs))
 
 
 @dataclass(frozen=True, slots=True)
@@ -261,16 +267,50 @@ def mt_conan_blint_db_build(
     project_spec: ConanProjectSpec,
     db_file: str | None = None,
     disassemble: bool = False,
+    project_outcomes=None,
 ):
     logger.debug("Running Conan package %s", project_spec.selector)
     try:
-        return add_project_conan_db(
+        artifacts = add_project_conan_db(
             project_spec,
             db_file=db_file,
             disassemble=disassemble,
         )
+        failure = None
+        status = "success"
+        if not artifacts:
+            status = "no_artifacts"
+            failure = build_failure_record(
+                stage="artifact-discovery",
+                message=f"No Conan artifacts were retained for {project_spec.selector}",
+            )
+        _record_outcome(
+            project_outcomes,
+            selector=project_spec.selector,
+            project_name=project_spec.name,
+            ecosystem="conan",
+            build_system="conan",
+            status=status,
+            artifact_count=len(artifacts),
+            failure=failure,
+        )
+        return artifacts
     except (OperationalError, RuntimeError) as exc:
         logger.info("error encountered with %s", project_spec.selector)
         logger.error(exc)
         logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=project_spec.selector,
+            project_name=project_spec.name,
+            ecosystem="conan",
+            build_system="conan",
+            status="build_failed" if isinstance(exc, RuntimeError) else "ingest_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="build" if isinstance(exc, RuntimeError) else "database",
+                message=str(exc),
+                exception=exc,
+            ),
+        )
         return []

--- a/blint_db/projects_compiler/homebrew.py
+++ b/blint_db/projects_compiler/homebrew.py
@@ -19,6 +19,12 @@ from blint_db.handlers.language_handlers.homebrew_handler import (
     homebrew_repository,
 )
 from blint_db.ingest import ingest_binary_file
+from blint_db.utils.provenance import build_failure_record, build_project_outcome
+
+
+def _record_outcome(project_outcomes, **kwargs):
+    if project_outcomes is not None:
+        project_outcomes.append(build_project_outcome(**kwargs))
 
 
 def _formula_payload(formula_info: dict) -> dict:
@@ -62,15 +68,10 @@ def _matching_installed_entry(formula: dict, keg_root: Path) -> dict | None:
 
 
 def add_project_homebrew_db(formula_name, db_file=None, disassemble=False):
-    try:
-        formula_info = ensure_homebrew_formula(formula_name)
-        formula = _formula_payload(formula_info)
-        project_metadata = _formula_project_metadata(formula)
-        keg_roots = homebrew_keg_roots(formula_info)
-    except RuntimeError:
-        logger.info(f"error encountered with {formula_name}")
-        logger.error(traceback.format_exc())
-        return []
+    formula_info = ensure_homebrew_formula(formula_name)
+    formula = _formula_payload(formula_info)
+    project_metadata = _formula_project_metadata(formula)
+    keg_roots = homebrew_keg_roots(formula_info)
     all_artifacts: list[str] = []
     if not keg_roots:
         raise RuntimeError(f"No installed Homebrew kegs found for {formula_name}")
@@ -128,16 +129,54 @@ def add_project_homebrew_db(formula_name, db_file=None, disassemble=False):
     return sorted(dict.fromkeys(all_artifacts))
 
 
-def mt_homebrew_blint_db_build(formula_name, db_file=None, disassemble=False):
+def mt_homebrew_blint_db_build(
+    formula_name,
+    db_file=None,
+    disassemble=False,
+    project_outcomes=None,
+):
     logger.debug(f"Running Homebrew formula {formula_name}")
     try:
-        return add_project_homebrew_db(
+        artifacts = add_project_homebrew_db(
             formula_name,
             db_file=db_file,
             disassemble=disassemble,
         )
-    except OperationalError as exc:
+        failure = None
+        status = "success"
+        if not artifacts:
+            status = "no_artifacts"
+            failure = build_failure_record(
+                stage="artifact-discovery",
+                message=f"No Homebrew artifacts were retained for {formula_name}",
+            )
+        _record_outcome(
+            project_outcomes,
+            selector=formula_name,
+            project_name=formula_name,
+            ecosystem="homebrew",
+            build_system="homebrew",
+            status=status,
+            artifact_count=len(artifacts),
+            failure=failure,
+        )
+        return artifacts
+    except (OperationalError, RuntimeError) as exc:
         logger.info(f"error encountered with {formula_name}")
         logger.error(exc)
         logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=formula_name,
+            project_name=formula_name,
+            ecosystem="homebrew",
+            build_system="homebrew",
+            status="build_failed" if isinstance(exc, RuntimeError) else "ingest_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="build" if isinstance(exc, RuntimeError) else "database",
+                message=str(exc),
+                exception=exc,
+            ),
+        )
         return []

--- a/blint_db/projects_compiler/meson.py
+++ b/blint_db/projects_compiler/meson.py
@@ -19,10 +19,17 @@ from blint_db import (
 )
 from blint_db.handlers.git_handler import git_checkout_commit, git_clone
 from blint_db.handlers.language_handlers.meson_handler import (
+    build_dir_for,
     find_meson_executables,
     meson_build,
 )
 from blint_db.ingest import ingest_binary_file
+from blint_db.utils.provenance import build_failure_record, build_project_outcome
+
+
+def _record_outcome(project_outcomes, **kwargs):
+    if project_outcomes is not None:
+        project_outcomes.append(build_project_outcome(**kwargs))
 
 
 def git_clone_wrapdb():
@@ -96,7 +103,12 @@ def add_project_meson_db(project_name, wrap_file, db_file=None, disassemble=Fals
     return execs
 
 
-def mt_meson_blint_db_build(project_name_wrap_tuple, db_file=None, disassemble=False):
+def mt_meson_blint_db_build(
+    project_name_wrap_tuple,
+    db_file=None,
+    disassemble=False,
+    project_outcomes=None,
+):
     project_name, wrap_file = project_name_wrap_tuple
     logger.debug(f"Running {project_name}")
     try:
@@ -106,11 +118,67 @@ def mt_meson_blint_db_build(project_name_wrap_tuple, db_file=None, disassemble=F
             db_file=db_file,
             disassemble=disassemble,
         )
-    except RuntimeError:
+        failure = None
+        status = "success"
+        if not execs:
+            status = "no_artifacts"
+            failure = build_failure_record(
+                stage="artifact-discovery",
+                message=f"No Meson artifacts were retained for {project_name}",
+            )
+        _record_outcome(
+            project_outcomes,
+            selector=project_name,
+            project_name=project_name,
+            ecosystem="wrapdb",
+            build_system="meson",
+            status=status,
+            artifact_count=len(execs),
+            failure=failure,
+            details={"wrap_file": str(wrap_file)} if wrap_file else None,
+        )
+    except RuntimeError as e:
+        logger.info(f"error encountered with {project_name}")
+        logger.error(e)
+        meson_log_file = build_dir_for(project_name) / "meson-logs" / "meson-log.txt"
+        if meson_log_file.exists():
+            logger.error(f"Meson log for {project_name}: {meson_log_file}")
+        logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=project_name,
+            project_name=project_name,
+            ecosystem="wrapdb",
+            build_system="meson",
+            status="build_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="build",
+                message=str(e),
+                exception=e,
+                log_file=str(meson_log_file) if meson_log_file.exists() else None,
+            ),
+            details={"wrap_file": str(wrap_file)} if wrap_file else None,
+        )
         return []
     except OperationalError as e:
         logger.info(f"error encountered with {project_name}")
         logger.error(e)
         logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=project_name,
+            project_name=project_name,
+            ecosystem="wrapdb",
+            build_system="meson",
+            status="ingest_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="database",
+                message=str(e),
+                exception=e,
+            ),
+            details={"wrap_file": str(wrap_file)} if wrap_file else None,
+        )
         return []
     return execs

--- a/blint_db/projects_compiler/vcpkg.py
+++ b/blint_db/projects_compiler/vcpkg.py
@@ -23,6 +23,12 @@ from blint_db.handlers.language_handlers.vcpkg_handler import (
     vcpkg_build,
 )
 from blint_db.ingest import ingest_binary_file
+from blint_db.utils.provenance import build_failure_record, build_project_outcome
+
+
+def _record_outcome(project_outcomes, **kwargs):
+    if project_outcomes is not None:
+        project_outcomes.append(build_project_outcome(**kwargs))
 
 
 def git_clone_vcpkg():
@@ -125,7 +131,13 @@ def add_project_vcpkg_db(project_name, vcpkg_json, db_file=None, disassemble=Fal
     return execs
 
 
-def mt_vcpkg_blint_db_build(project_name, vcpkg_json, db_file=None, disassemble=False):
+def mt_vcpkg_blint_db_build(
+    project_name,
+    vcpkg_json,
+    db_file=None,
+    disassemble=False,
+    project_outcomes=None,
+):
     logger.debug(f"Running {project_name} with vcpkg {vcpkg_json}")
     try:
         execs = add_project_vcpkg_db(
@@ -134,9 +146,43 @@ def mt_vcpkg_blint_db_build(project_name, vcpkg_json, db_file=None, disassemble=
             db_file=db_file,
             disassemble=disassemble,
         )
+        failure = None
+        status = "success"
+        if not execs:
+            status = "no_artifacts"
+            failure = build_failure_record(
+                stage="artifact-discovery",
+                message=f"No vcpkg artifacts were retained for {project_name}",
+            )
+        _record_outcome(
+            project_outcomes,
+            selector=project_name,
+            project_name=project_name,
+            ecosystem="vcpkg",
+            build_system="vcpkg",
+            status=status,
+            artifact_count=len(execs),
+            failure=failure,
+            details={"vcpkg_json": str(vcpkg_json)} if vcpkg_json else None,
+        )
         return execs
     except (OperationalError, RuntimeError) as e:
         logger.info(f"error encountered with {project_name}")
         logger.error(e)
         logger.error(traceback.format_exc())
+        _record_outcome(
+            project_outcomes,
+            selector=project_name,
+            project_name=project_name,
+            ecosystem="vcpkg",
+            build_system="vcpkg",
+            status="build_failed" if isinstance(e, RuntimeError) else "ingest_failed",
+            artifact_count=0,
+            failure=build_failure_record(
+                stage="build" if isinstance(e, RuntimeError) else "database",
+                message=str(e),
+                exception=e,
+            ),
+            details={"vcpkg_json": str(vcpkg_json)} if vcpkg_json else None,
+        )
         return []

--- a/blint_db/utils/provenance.py
+++ b/blint_db/utils/provenance.py
@@ -12,7 +12,7 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 from blint_db import (
     BLINT_DB_SCHEMA_FAMILY,
@@ -47,7 +47,7 @@ from blint_db import (
     WRAPDB_LOCATION,
     WRAPDB_URL,
 )
-from blint_db.handlers.sqlite_handler import execute_statement
+from blint_db.handlers.sqlite_handler import collect_database_stats, execute_statement
 from blint_db.utils.json import dump_json_file
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -204,6 +204,95 @@ def _db_table_counts(db_file: str | os.PathLike) -> dict[str, int]:
     return {str(row["table_name"]): int(row["count"]) for row in rows}
 
 
+def build_failure_record(
+    *,
+    stage: str,
+    message: str,
+    returncode: int | None = None,
+    exception: BaseException | None = None,
+    **details,
+) -> dict[str, Any]:
+    failure = {
+        "stage": stage,
+        "message": message,
+    }
+    if returncode is not None:
+        failure["returncode"] = returncode
+    if exception is not None:
+        failure["exception_type"] = type(exception).__name__
+    failure.update(
+        {
+            key: value
+            for key, value in details.items()
+            if value not in (None, [], {}, "")
+        }
+    )
+    return failure
+
+
+def build_project_outcome(
+    *,
+    selector: str,
+    project_name: str,
+    ecosystem: str,
+    build_system: str,
+    status: str,
+    artifact_count: int = 0,
+    failure: Mapping[str, Any] | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    outcome = {
+        "selector": selector,
+        "project_name": project_name,
+        "ecosystem": ecosystem,
+        "build_system": build_system,
+        "status": status,
+        "artifact_count": int(artifact_count),
+    }
+    if failure:
+        outcome["failure"] = dict(failure)
+    if details:
+        normalized_details = {
+            key: value
+            for key, value in details.items()
+            if value not in (None, [], {}, "")
+        }
+        if normalized_details:
+            outcome["details"] = normalized_details
+    return outcome
+
+
+def summarize_project_outcomes(
+    project_outcomes: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    normalized_outcomes = [dict(outcome) for outcome in (project_outcomes or [])]
+    status_counts: dict[str, int] = {}
+    build_failures: list[dict[str, Any]] = []
+    for outcome in normalized_outcomes:
+        status = str(outcome.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        failure = outcome.get("failure")
+        if isinstance(failure, Mapping):
+            build_failures.append(
+                {
+                    "selector": outcome.get("selector"),
+                    "project_name": outcome.get("project_name"),
+                    "ecosystem": outcome.get("ecosystem"),
+                    "build_system": outcome.get("build_system"),
+                    "status": status,
+                    **dict(failure),
+                }
+            )
+    return {
+        "attempted_count": len(normalized_outcomes),
+        "success_count": status_counts.get("success", 0),
+        "failure_count": len(build_failures),
+        "status_counts": status_counts,
+        "build_failures": build_failures,
+        "outcomes": normalized_outcomes,
+    }
+
+
 def build_run_metadata(
     *,
     command: str,
@@ -212,9 +301,12 @@ def build_run_metadata(
     disassemble: bool = False,
     test_mode: bool = False,
     selected_projects: Sequence[str] | None = None,
+    project_outcomes: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     db_path = Path(db_file)
     metadata_path = Path(metadata_file)
+    projects = summarize_project_outcomes(project_outcomes)
+    projects["selected_count"] = len(selected_projects or [])
     return {
         "generated_at": _utc_now(),
         "schema": {
@@ -358,7 +450,9 @@ def build_run_metadata(
             "path": str(db_path),
             "size_bytes": db_path.stat().st_size if db_path.exists() else 0,
             "table_counts": _db_table_counts(db_path),
+            "sqlite_stats": collect_database_stats(db_path),
         },
+        "projects": projects,
     }
 
 
@@ -370,6 +464,7 @@ def write_run_metadata(
     disassemble: bool = False,
     test_mode: bool = False,
     selected_projects: Sequence[str] | None = None,
+    project_outcomes: Sequence[Mapping[str, Any]] | None = None,
 ) -> Path:
     target_path = (
         Path(metadata_file) if metadata_file else default_run_metadata_path(db_file)
@@ -384,6 +479,7 @@ def write_run_metadata(
             disassemble=disassemble,
             test_mode=test_mode,
             selected_projects=selected_projects,
+            project_outcomes=project_outcomes,
         ),
     )
     return target_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -63,6 +64,15 @@ def test_build_meson_subcommand_accepts_project_selection_flags_after_command():
     assert args.command == "build-meson"
     assert args.sel_project == ["zstd", "bzip2"]
     assert args.test_mode is True
+    assert args.remove_after_build is True
+
+
+def test_build_meson_subcommand_can_retain_artifacts():
+    parser = build_parser()
+    args = parser.parse_args(["build-meson", "--retain-build-artifacts", "-s", "zlib"])
+
+    assert args.command == "build-meson"
+    assert args.remove_after_build is False
 
 
 def test_build_homebrew_subcommand_accepts_project_selection_flags_after_command():
@@ -139,6 +149,71 @@ def test_meson_add_blint_bom_process_resolves_selected_projects(monkeypatch):
     assert removed_projects == ["zstd"]
 
 
+def test_meson_add_blint_bom_process_can_retain_artifacts(monkeypatch):
+    built_projects = []
+    removed_projects = []
+
+    monkeypatch.setattr(
+        "blint_db.cli.get_wrapdb_projects",
+        lambda: [("zstd", "/tmp/zstd.wrap")],
+    )
+    monkeypatch.setattr(
+        "blint_db.cli.mt_meson_blint_db_build",
+        lambda project_tuple, **kwargs: built_projects.append(project_tuple) or [],
+    )
+    monkeypatch.setattr(
+        "blint_db.cli.remove_wrapdb_project",
+        lambda project_name: removed_projects.append(project_name),
+    )
+
+    meson_add_blint_bom_process(
+        db_file="demo.db",
+        sel_project=["zstd"],
+        remove_after_build=False,
+    )
+
+    assert built_projects == [("zstd", "/tmp/zstd.wrap")]
+    assert removed_projects == []
+
+
+def test_meson_add_blint_bom_process_collects_project_outcomes(monkeypatch):
+    monkeypatch.setattr(
+        "blint_db.cli.get_wrapdb_projects",
+        lambda: [("zstd", "/tmp/zstd.wrap")],
+    )
+
+    def _fake_builder(project_tuple, **kwargs):
+        kwargs["project_outcomes"].append(
+            {
+                "selector": project_tuple[0],
+                "project_name": project_tuple[0],
+                "ecosystem": "wrapdb",
+                "build_system": "meson",
+                "status": "build_failed",
+                "artifact_count": 0,
+                "failure": {"stage": "build", "message": "compile failed"},
+            }
+        )
+        return []
+
+    monkeypatch.setattr("blint_db.cli.mt_meson_blint_db_build", _fake_builder)
+    monkeypatch.setattr("blint_db.cli.remove_wrapdb_project", lambda project_name: None)
+
+    outcomes = meson_add_blint_bom_process(db_file="demo.db", sel_project=["zstd"])
+
+    assert outcomes == [
+        {
+            "selector": "zstd",
+            "project_name": "zstd",
+            "ecosystem": "wrapdb",
+            "build_system": "meson",
+            "status": "build_failed",
+            "artifact_count": 0,
+            "failure": {"stage": "build", "message": "compile failed"},
+        }
+    ]
+
+
 def test_meson_add_blint_bom_process_rejects_unknown_selected_projects(monkeypatch):
     monkeypatch.setattr(
         "blint_db.cli.get_wrapdb_projects",
@@ -176,6 +251,39 @@ def test_vcpkg_add_blint_bom_process_resolves_selected_projects(tmp_path, monkey
         ("zlib", str(Path(tmp_path) / "ports" / "zlib" / "vcpkg.json"))
     ]
     assert removed_projects == ["zlib"]
+
+
+def test_vcpkg_add_blint_bom_process_can_retain_artifacts(tmp_path, monkeypatch):
+    built_projects = []
+    removed_projects = []
+
+    monkeypatch.setattr(
+        "blint_db.cli.get_vcpkg_projects",
+        lambda: ["zlib"],
+    )
+    monkeypatch.setattr(
+        "blint_db.cli.mt_vcpkg_blint_db_build",
+        lambda project_name, vcpkg_json, **kwargs: built_projects.append(
+            (project_name, str(vcpkg_json))
+        )
+        or [],
+    )
+    monkeypatch.setattr(
+        "blint_db.cli.remove_vcpkg_project",
+        lambda project_name: removed_projects.append(project_name),
+    )
+    monkeypatch.setattr("blint_db.cli.VCPKG_LOCATION", Path(tmp_path))
+
+    vcpkg_add_blint_bom_process(
+        db_file="demo.db",
+        sel_project=["zlib"],
+        remove_after_build=False,
+    )
+
+    assert built_projects == [
+        ("zlib", str(Path(tmp_path) / "ports" / "zlib" / "vcpkg.json"))
+    ]
+    assert removed_projects == []
 
 
 def test_vcpkg_add_blint_bom_process_rejects_unknown_selected_projects(monkeypatch):
@@ -419,6 +527,7 @@ def test_main_ingests_metadata_file_from_cli(
 
     captured = capsys.readouterr()
     assert "Ingested binary_id=" in captured.out
+    assert "Compacted database" in captured.out
     project_rows = execute_statement(
         "SELECT name, purl FROM Projects",
         db_file=str(db_file),
@@ -456,8 +565,52 @@ def test_main_build_meson_writes_run_metadata_file(tmp_path, monkeypatch, capsys
     main()
 
     captured = capsys.readouterr()
+    assert "Compacted database" in captured.out
     assert "Wrote build metadata to" in captured.out
     assert metadata_file.exists()
+
+
+def test_main_build_meson_run_metadata_includes_project_outcomes(
+    tmp_path, monkeypatch, capsys
+):
+    db_file = tmp_path / "build.db"
+    metadata_file = tmp_path / "build-run.json"
+    monkeypatch.setattr(
+        "blint_db.cli.meson_add_blint_bom_process",
+        lambda **kwargs: [
+            {
+                "selector": "zlib",
+                "project_name": "zlib",
+                "ecosystem": "wrapdb",
+                "build_system": "meson",
+                "status": "build_failed",
+                "artifact_count": 0,
+                "failure": {"stage": "build", "message": "compile failed"},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "blint-db",
+            "--db-file",
+            str(db_file),
+            "--run-metadata-file",
+            str(metadata_file),
+            "build-meson",
+            "-s",
+            "zlib",
+        ],
+    )
+
+    main()
+
+    captured = capsys.readouterr()
+    assert "Wrote build metadata to" in captured.out
+    payload = json.loads(metadata_file.read_text(encoding="utf-8"))
+    assert payload["projects"]["attempted_count"] == 1
+    assert payload["projects"]["failure_count"] == 1
+    assert payload["projects"]["build_failures"][0]["selector"] == "zlib"
 
 
 def test_main_build_cargo_writes_run_metadata_file(tmp_path, monkeypatch, capsys):
@@ -484,6 +637,7 @@ def test_main_build_cargo_writes_run_metadata_file(tmp_path, monkeypatch, capsys
     main()
 
     captured = capsys.readouterr()
+    assert "Compacted database" in captured.out
     assert "Wrote build metadata to" in captured.out
     assert metadata_file.exists()
 
@@ -512,5 +666,6 @@ def test_main_build_conan_writes_run_metadata_file(tmp_path, monkeypatch, capsys
     main()
 
     captured = capsys.readouterr()
+    assert "Compacted database" in captured.out
     assert "Wrote build metadata to" in captured.out
     assert metadata_file.exists()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -48,6 +48,28 @@ def test_write_run_metadata_records_database_counts_and_selection(
         disassemble=True,
         test_mode=True,
         selected_projects=["zlib", "bzip2"],
+        project_outcomes=[
+            provenance.build_project_outcome(
+                selector="zlib",
+                project_name="zlib",
+                ecosystem="vcpkg",
+                build_system="vcpkg",
+                status="success",
+                artifact_count=3,
+            ),
+            provenance.build_project_outcome(
+                selector="bzip2",
+                project_name="bzip2",
+                ecosystem="vcpkg",
+                build_system="vcpkg",
+                status="build_failed",
+                failure=provenance.build_failure_record(
+                    stage="build",
+                    message="compile failed",
+                    returncode=1,
+                ),
+            ),
+        ],
     )
 
     payload = json.loads(metadata_path.read_text(encoding="utf-8"))
@@ -56,6 +78,13 @@ def test_write_run_metadata_records_database_counts_and_selection(
     assert payload["run"]["disassemble"] is True
     assert payload["run"]["test_mode"] is True
     assert payload["run"]["selected_projects"] == ["zlib", "bzip2"]
+    assert payload["projects"]["selected_count"] == 2
+    assert payload["projects"]["attempted_count"] == 2
+    assert payload["projects"]["success_count"] == 1
+    assert payload["projects"]["failure_count"] == 1
+    assert payload["projects"]["status_counts"] == {"success": 1, "build_failed": 1}
+    assert payload["projects"]["build_failures"][0]["selector"] == "bzip2"
+    assert payload["projects"]["build_failures"][0]["returncode"] == 1
     assert payload["database"]["table_counts"]["Projects"] == 0
     assert payload["database"]["table_counts"]["Binaries"] == 0
     assert payload["tool_versions"]["meson"] == "1.11.1"
@@ -221,3 +250,36 @@ def test_write_run_metadata_records_conan_context(tmp_path, monkeypatch):
         "fmt/11.2.0#shared-release",
         "zlib/1.3.1#static-debug",
     ]
+
+
+def test_summarize_project_outcomes_extracts_structured_failures():
+    summary = provenance.summarize_project_outcomes(
+        [
+            provenance.build_project_outcome(
+                selector="zlib",
+                project_name="zlib",
+                ecosystem="wrapdb",
+                build_system="meson",
+                status="success",
+                artifact_count=2,
+            ),
+            provenance.build_project_outcome(
+                selector="bzip2",
+                project_name="bzip2",
+                ecosystem="wrapdb",
+                build_system="meson",
+                status="no_artifacts",
+                failure=provenance.build_failure_record(
+                    stage="artifact-discovery",
+                    message="No artifacts",
+                ),
+            ),
+        ]
+    )
+
+    assert summary["attempted_count"] == 2
+    assert summary["success_count"] == 1
+    assert summary["failure_count"] == 1
+    assert summary["status_counts"] == {"success": 1, "no_artifacts": 1}
+    assert summary["build_failures"][0]["selector"] == "bzip2"
+    assert summary["build_failures"][0]["stage"] == "artifact-discovery"

--- a/tests/test_sqlite_handler.py
+++ b/tests/test_sqlite_handler.py
@@ -2,6 +2,8 @@ import json
 from copy import deepcopy
 
 from blint_db.handlers.sqlite_handler import (
+    collect_database_stats,
+    compact_database,
     create_database,
     execute_statement,
     fetch_binary,
@@ -36,6 +38,10 @@ def test_create_database_initializes_v2_schema(tmp_path):
         "Dependencies",
         "FunctionFingerprints",
     }.issubset(tables)
+
+    stats = collect_database_stats(str(db_file))
+    assert stats["page_size"] == 4096
+    assert stats["size_bytes"] > 0
 
 
 def test_ingest_metadata_stores_symbols_dependencies_and_hashes(
@@ -272,3 +278,26 @@ def test_ingest_metadata_file_supports_precomputed_blint_json(
     binary_row = fetch_binary(result["binary_id"], db_file=str(db_file))
     assert binary_row["project_name"] == "demo-json"
     assert binary_row["project_purl"] == "pkg:generic/demo-json@1.0.0"
+
+
+def test_compact_database_truncates_freelist_after_deletes(tmp_path, isolated_metadata):
+    db_file = tmp_path / "blint-v2.db"
+    ingest_metadata(
+        metadata=isolated_metadata,
+        db_file=str(db_file),
+        project_name="demo",
+        project_purl="pkg:generic/demo@1.0.0",
+        ecosystem="manual",
+        build_system="manual",
+    )
+
+    before_delete = collect_database_stats(str(db_file))
+    execute_statement("DELETE FROM Symbols", db_file=str(db_file))
+    after_delete = collect_database_stats(str(db_file))
+    result = compact_database(str(db_file))
+    after_compact = result["after"]
+
+    assert before_delete["size_bytes"] > 0
+    assert after_delete["freelist_count"] >= 0
+    assert after_compact["freelist_count"] <= after_delete["freelist_count"]
+    assert after_compact["wal_size_bytes"] == 0


### PR DESCRIPTION
- Add compact_database() and collect_database_stats() to sqlite_handler
- Run WAL checkpoint, VACUUM, and incremental_vacuum after every build/ingest command
- Add SQLite PRAGMAs (page_size=4096, auto_vacuum=INCREMENTAL, etc.) and new lookup indexes
- Include sqlite_stats in provenance run metadata sidecar
- Fix orasclient.py to use REGISTRY/IMAGE_NAME env vars and pass server= to login()
- Update README with compaction policy, storage tuning docs, and end-to-end validation examples

test improvements
track build failures